### PR TITLE
routing: initial seeds

### DIFF
--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/02f86daff92bfdc5
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/02f86daff92bfdc5
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(0)
+rune('\u008e')
+rune('V')
+uint64(0)
+uint64(91)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/282cc7f690db7a1c
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/282cc7f690db7a1c
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(0)
+rune('\x00')
+int32(-54)
+uint64(0)
+uint64(0)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/380c3be7effe1a7b
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/380c3be7effe1a7b
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(0)
+rune('\x00')
+rune('\x00')
+uint64(54)
+uint64(0)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/3c7d05b58598a2a0
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/3c7d05b58598a2a0
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(77)
+rune('7')
+rune('\x00')
+uint64(0)
+uint64(0)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/3f41695901bb2194
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/3f41695901bb2194
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(86)
+int32(-86)
+int32(-67)
+uint64(0)
+uint64(67)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/41e33b6307660944
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/41e33b6307660944
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(0)
+rune('\x19')
+int32(-8)
+uint64(0)
+uint64(8)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/5c22c36597f50353
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/5c22c36597f50353
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(0)
+int32(-1)
+int32(-57)
+uint64(0)
+uint64(20)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/5d1feab18e3ae0ad
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/5d1feab18e3ae0ad
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(0)
+int32(-26)
+rune('D')
+uint64(70)
+uint64(0)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/68b88a248ad021f6
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/68b88a248ad021f6
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(1)
+rune('\n')
+int32(-1)
+uint64(0)
+uint64(1)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/7b654ac67307f154
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/7b654ac67307f154
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(56)
+rune('7')
+rune('Y')
+uint64(53)
+uint64(8)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/7e947b39fd493b50
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/7e947b39fd493b50
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(1)
+rune(')')
+int32(-6)
+uint64(0)
+uint64(7)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/8c0037950f459652
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/8c0037950f459652
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(98)
+int32(-86)
+rune('%')
+uint64(5)
+uint64(153)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/c3d0cb77ba8b4662
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/c3d0cb77ba8b4662
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(77)
+rune('7')
+rune('\x00')
+uint64(0)
+uint64(13)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/cac2f9a1d668fea7
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/cac2f9a1d668fea7
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(0)
+int32(-86)
+rune('%')
+uint64(5)
+uint64(65)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/d07fd5790be76a3f
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/d07fd5790be76a3f
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(100)
+rune('\x00')
+int32(-35)
+uint64(60)
+uint64(0)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/d42395611d01696f
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/d42395611d01696f
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(46)
+int32(-58)
+int32(-71)
+uint64(78)
+uint64(6)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/d4ee12fa2b8d1e83
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/d4ee12fa2b8d1e83
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(0)
+int32(-1)
+int32(-37)
+uint64(17)
+uint64(20)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/d584f7ef2cb3afe0
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/d584f7ef2cb3afe0
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(131)
+rune('»')
+rune('Y')
+uint64(53)
+uint64(114)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/db8befffcf8a5002
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/db8befffcf8a5002
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(77)
+int32(-66)
+int32(-67)
+uint64(0)
+uint64(0)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/e0ba4aa1e8d2a2b8
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/e0ba4aa1e8d2a2b8
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(1)
+int32(-21)
+int32(-6)
+uint64(0)
+uint64(33)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/e9c819f96d63f56a
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/e9c819f96d63f56a
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(77)
+rune('\x02')
+rune('\x00')
+uint64(36)
+uint64(0)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/f78019959e1a79c0
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/f78019959e1a79c0
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(100)
+int32(-36)
+int32(-35)
+uint64(60)
+uint64(0)

--- a/routing/testdata/fuzz/FuzzInboundOutboundFee/fbdc0d5d5681e03a
+++ b/routing/testdata/fuzz/FuzzInboundOutboundFee/fbdc0d5d5681e03a
@@ -1,0 +1,6 @@
+go test fuzz v1
+uint64(0)
+rune(']')
+rune('\x00')
+uint64(0)
+uint64(0)

--- a/routing/testdata/fuzz/FuzzProbability/04528c70acc52340
+++ b/routing/testdata/fuzz/FuzzProbability/04528c70acc52340
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint64(100)
+uint64(200)
+uint64(200)
+uint64(43)

--- a/routing/testdata/fuzz/FuzzProbability/26f9f6f2e1c5b6d8
+++ b/routing/testdata/fuzz/FuzzProbability/26f9f6f2e1c5b6d8
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint64(15)
+uint64(75)
+uint64(0)
+uint64(66)

--- a/routing/testdata/fuzz/FuzzProbability/3e09919cab90bc68
+++ b/routing/testdata/fuzz/FuzzProbability/3e09919cab90bc68
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint64(2)
+uint64(7)
+uint64(4)
+uint64(0)

--- a/routing/testdata/fuzz/FuzzProbability/557f4e4e7a2c508e
+++ b/routing/testdata/fuzz/FuzzProbability/557f4e4e7a2c508e
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint64(45)
+uint64(0)
+uint64(0)
+uint64(0)

--- a/routing/testdata/fuzz/FuzzProbability/6249fd3cee80dd6f
+++ b/routing/testdata/fuzz/FuzzProbability/6249fd3cee80dd6f
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint64(114)
+uint64(0)
+uint64(69)
+uint64(104)

--- a/routing/testdata/fuzz/FuzzProbability/6490733a322fbdc9
+++ b/routing/testdata/fuzz/FuzzProbability/6490733a322fbdc9
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint64(0)
+uint64(0)
+uint64(0)
+uint64(8)

--- a/routing/testdata/fuzz/FuzzProbability/6881281b55fbb4a6
+++ b/routing/testdata/fuzz/FuzzProbability/6881281b55fbb4a6
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint64(35)
+uint64(0)
+uint64(81)
+uint64(0)

--- a/routing/testdata/fuzz/FuzzProbability/6b43ae3db0e2039f
+++ b/routing/testdata/fuzz/FuzzProbability/6b43ae3db0e2039f
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint64(91)
+uint64(16)
+uint64(71)
+uint64(8)

--- a/routing/testdata/fuzz/FuzzProbability/783000779cc3c88a
+++ b/routing/testdata/fuzz/FuzzProbability/783000779cc3c88a
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint64(40)
+uint64(51)
+uint64(98)
+uint64(7)

--- a/routing/testdata/fuzz/FuzzProbability/7b8b13c29004cb22
+++ b/routing/testdata/fuzz/FuzzProbability/7b8b13c29004cb22
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint64(45)
+uint64(0)
+uint64(100)
+uint64(0)

--- a/routing/testdata/fuzz/FuzzProbability/b6717b096e146f11
+++ b/routing/testdata/fuzz/FuzzProbability/b6717b096e146f11
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint64(60)
+uint64(210)
+uint64(80)
+uint64(31)

--- a/routing/testdata/fuzz/FuzzProbability/c9eba3612d095ac6
+++ b/routing/testdata/fuzz/FuzzProbability/c9eba3612d095ac6
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint64(49)
+uint64(0)
+uint64(50)
+uint64(0)

--- a/routing/testdata/fuzz/FuzzProbability/f19a52a08b1b6e41
+++ b/routing/testdata/fuzz/FuzzProbability/f19a52a08b1b6e41
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint64(60)
+uint64(200)
+uint64(80)
+uint64(43)


### PR DESCRIPTION
Add seeds for the FuzzInboundOutboundFee and FuzzProbability targets.