### PR TITLE
profile_diffs.py: script to compare Go coverage profiles, outputs new…

### DIFF
--- a/profile_diffs.py
+++ b/profile_diffs.py
@@ -1,0 +1,69 @@
+import sys
+
+def find_newly_hit_blocks(first_profile_path, second_profile_path, output_path):
+    """
+    Given two paths to Go coverage profiles, determine which basic blocks are hit
+    in the second coverage profile and not the first. This can be used to tell if
+    coverage has increased from the first profile to the second profile.
+    TODO: Compare the # of times that a basic block has been hit as well.
+
+    Args:
+        first_profile_path (str): Path to the first Go coverage profile.
+        second_profile_path (str): Path to the second Go coverage profile.
+        output_path (str): Path to save the new code blocks.
+    """
+    try:
+        # Read the two profiles
+        with open(first_profile_path, 'r') as prof1, open(second_profile_path, 'r') as prof2:
+            prof1_lines = prof1.readlines()
+            prof2_lines = prof2.readlines()
+
+        # Parse lines into sets of code blocks
+        def parse_coverage(lines):
+            coverage = {}
+            for line in lines:
+                # Split on whitespace
+                parts = line.split()
+
+                # The last digit in a coverage profile denotes how many times it was
+                # hit during the profile. Extract this value. The "block" is the part
+                # of the coverage profile _before_ the hit counter.
+                if len(parts) > 0 and parts[-1].isdigit():
+                    block = " ".join(parts[:-1])
+                    hit = int(parts[-1])
+                    coverage[block] = hit
+
+            # Return the coverage map for comparison.
+            return coverage
+
+        file1_coverage = parse_coverage(prof1_lines)
+        file2_coverage = parse_coverage(prof2_lines)
+
+        # Find blocks hit in the second profile but not in the first
+        newly_hit_blocks = []
+        for block, hit in file2_coverage.items():
+            if hit > 0 and file1_coverage.get(block, 0) == 0:
+                newly_hit_blocks.append(f"{block} {hit}\n")
+
+        # Write newly hit blocks to the output file
+        with open(output_path, 'w') as output_file:
+            output_file.writelines(newly_hit_blocks)
+
+        print(f"Newly hit blocks have been extracted and saved to: {output_path}")
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+def main(file1_path, file2_path, output_path):
+    find_newly_hit_blocks(file1_path, file2_path, output_path)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        print("Usage: python profile_diffs.py <profile1_path> <profile2_path> <output_path>")
+        sys.exit(1)
+
+    file1_path = sys.argv[1]
+    file2_path = sys.argv[2]
+    output_path = sys.argv[3]
+
+    main(file1_path, file2_path, output_path)


### PR DESCRIPTION
… blocks

This python script accepts two paths to Go coverage profiles and outputs the new code blocks that were hit in the second profile and not the first. If the script is used on both permutations of coverage profiles (e.g. `<profile1> <profile2>` in one run and `<profile2> <profile1>` in the other run), it's possible to see whether coverage increased or decreased fairly easily. The script should be adapted in the future to:
 - use branch coverage (see something like: https://github.com/junhwi/gobco/)
 - automatically parse this output data and tell how many new branches were hit and how many old branches were not hit.
 - compare the number of hit counters instead of "hit" vs. "not hit".

Help from ChatGPT 4o

Usage: `python python_diffs.py <path_to_coverage_profile1> <path_to_coverage_profile2> <path_to_output_file>`